### PR TITLE
add asset import

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
                     items: [
                         { text: "Introduction", link: "/guide/" },
                         { text: "Getting Started", link: "/guide/getting-started" },
+                        { text: "Asset Import", link: "/guide/asset-import" },
                         { text: "GPU Acceleration", link: "/guide/gpu-acceleration" },
                         { text: "Plugins", link: "/guide/plugins" }
                     ]

--- a/docs/guide/asset-import.md
+++ b/docs/guide/asset-import.md
@@ -1,0 +1,48 @@
+﻿# Asset Import
+
+By default, imgit is set up to detect and transform Markdown syntax in the source content. This works best for simple documentation and blog websites, but may not be flexible enough for more complex apps authored with frameworks like React.
+
+To better fit component-based apps, imgit allows importing media assets with `import` statement to manually author the desired HTML.
+
+Use `imgit:` namespace when importing a media asset to make imgit optimize it and return sources of the generated assets. For example, consider following [Astro](https://astro.build) page:
+
+```astro
+---
+import psd from "imgit:https://example.com/photo.psd";
+import mkv from "imgit:/public/video.mkv";
+---
+
+<img src={psd.content.encoded}
+     height={psd.info.height}
+     loading="lazy"/>
+
+<video src={mkv.content.encoded}
+       poster={mkv.content.cover}
+       height={mkv.info.height}
+       autoplay loop/>
+```
+
+Imported asset returns following default export:
+
+```ts
+type AssetImport = {
+    content: {
+        encoded: string,
+        dense?: string,
+        cover?: string,
+        safe?: string
+    },
+    info: {
+        type: string,
+        height: number,
+        width: number,
+        alpha: boolean
+    }
+};
+```
+
+— where `content` are the sources of the generated optimized files, which you can assign to the various `src` attributes of the built HTML. Additional `info` object contains metadata describing the imported asset, such its dimensions and MIME type, which may be helpful when building the host component.
+
+::: tip
+When using TypeScript, add `/// <reference types="imgit/client" />` to a `.d.ts` file anywhere under project source directory to correctly resolve virtual asset imports.
+:::

--- a/docs/guide/asset-import.md
+++ b/docs/guide/asset-import.md
@@ -9,7 +9,7 @@ Use `imgit:` namespace when importing a media asset to make imgit optimize it an
 ```astro
 ---
 import psd from "imgit:https://example.com/photo.psd";
-import mkv from "imgit:/public/video.mkv";
+import mkv from "imgit:/assets/video.mkv";
 ---
 
 <img src={psd.content.encoded}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -115,7 +115,7 @@ await fs.writeFile("./public/index.html", output);
 await exit();
 ```
 
-::: tip Example
+::: tip SAMPLE
 Find minimal sample on using imgit directly with Deno runtime on GitHub: https://github.com/elringus/imgit/tree/main/samples/minimal.
 :::
 

--- a/docs/guide/integrations/astro.md
+++ b/docs/guide/integrations/astro.md
@@ -33,7 +33,7 @@ into optimized HTML. For example, given following `index.md` page:
 ![](https://example.com/photo.psd)
 
 # MKV Video
-![](/public/video.mkv)
+![](/assets/video.mkv)
 
 # YouTube Video
 ![](https://www.youtube.com/watch?v=arbuYnJoLtU)
@@ -57,7 +57,7 @@ In case you'd like to instead manually build the HTML (eg, with custom component
 ```astro
 ---
 import psd from "imgit:https://example.com/photo.psd";
-import mkv from "imgit:/public/video.mkv";
+import mkv from "imgit:/assets/video.mkv";
 ---
 
 <img src={psd.content.encoded}

--- a/docs/guide/integrations/astro.md
+++ b/docs/guide/integrations/astro.md
@@ -25,6 +25,53 @@ export default defineConfig({
 
 :::
 
-::: tip Sample
+When building the project, imgit will automatically transform image Markdown syntax
+into optimized HTML. For example, given following `index.md` page:
+
+```md
+# PSD Image
+![](https://example.com/photo.psd)
+
+# MKV Video
+![](/public/video.mkv)
+
+# YouTube Video
+![](https://www.youtube.com/watch?v=arbuYnJoLtU)
+```
+
+— imgit will produce following HTML output:
+
+```html
+<h1>PSD Image</h1>
+<picture><source srcset="optimized-source.avif"></picture>
+
+<h1>MKV Video</h1>
+<video src="optimized-source.av1"></video>
+
+<h1>YouTube Video</h1>
+<div>optimized YouTube player</div>
+```
+
+In case you'd like to instead manually build the HTML (eg, with custom components), import the media assets with `imgit:` namespace:
+
+```astro
+---
+import psd from "imgit:https://example.com/photo.psd";
+import mkv from "imgit:/public/video.mkv";
+---
+
+<img src={psd.content.encoded}
+     height={psd.info.height}
+     loading="lazy"/>
+
+<video src={mkv.content.encoded}
+       poster={mkv.content.cover}
+       height={mkv.info.height}
+       autoplay loop/>
+```
+
+When using TypeScript, add `/// <reference types="imgit/client" />` to a `.d.ts` file anywhere inside project source directory to correctly resolve virtual asset imports.
+
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/astro
 :::

--- a/docs/guide/integrations/nuxt.md
+++ b/docs/guide/integrations/nuxt.md
@@ -23,6 +23,6 @@ export default defineNuxtConfig({
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/nuxt
 :::

--- a/docs/guide/integrations/remix.md
+++ b/docs/guide/integrations/remix.md
@@ -26,6 +26,6 @@ export default defineConfig({
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/remix
 :::

--- a/docs/guide/integrations/solid.md
+++ b/docs/guide/integrations/solid.md
@@ -26,6 +26,6 @@ export default defineConfig({
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/solid
 :::

--- a/docs/guide/integrations/svelte.md
+++ b/docs/guide/integrations/svelte.md
@@ -40,6 +40,6 @@ export default defineConfig({
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/svelte
 :::

--- a/docs/guide/integrations/vite.md
+++ b/docs/guide/integrations/vite.md
@@ -25,6 +25,6 @@ export default defineConfig({
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/vite
 :::

--- a/docs/guide/integrations/vitepress.md
+++ b/docs/guide/integrations/vitepress.md
@@ -42,6 +42,6 @@ export default { extends: { Layout: DefaultTheme.Layout } };
 
 :::
 
-::: tip Sample
+::: tip SAMPLE
 https://github.com/elringus/imgit/tree/main/samples/vitepress
 :::

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,6 @@
         "typescript": "^5.3.3",
         "vitepress": "^1.0.0-rc.42",
         "typedoc-vitepress-theme": "^1.0.0-next.9",
-        "imgit": "^0.2.0"
+        "imgit": "^0.2.1"
     }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,6 @@
         "typescript": "^5.3.3",
         "vitepress": "^1.0.0-rc.42",
         "typedoc-vitepress-theme": "^1.0.0-next.9",
-        "imgit": "^0.1.3"
+        "imgit": "^0.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Elringus (https://elringus.me)",
     "license": "MIT",
     "keywords": ["CLS", "lazy-load", "embed", "size", "encode", "compress", "md", "avif", "vite-plugin"],
-    "repository": { "type": "git", "url": "https://github.com/elringus/imgit.git" },
+    "repository": { "type": "git", "url": "git+https://github.com/elringus/imgit.git" },
     "funding": "https://github.com/sponsors/elringus",
     "homepage": "https://imgit.dev",
     "bugs": { "url": "https://github.com/elringus/imgit/issues" },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "devDependencies": {
         "typescript": "^5.3.3",
-        "vitest": "^1.1.3",
-        "@vitest/coverage-v8": "^1.1.3"
+        "vitest": "^1.2.2",
+        "@vitest/coverage-v8": "^1.2.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "imgit",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "description": "Transform images, video and YouTube links to HTML optimized for web vitals.",
     "author": "Elringus (https://elringus.me)",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "imgit",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Transform images, video and YouTube links to HTML optimized for web vitals.",
     "author": "Elringus (https://elringus.me)",
     "license": "MIT",

--- a/samples/astro/README.md
+++ b/samples/astro/README.md
@@ -10,4 +10,4 @@ Example on plugging imgit to [astro](https://astro.build) web framework:
 > [!IMPORTANT]
 > Initial build could take up to 5 minutes for all the sample assets referenced in index.astro to fetch and encode. The files will be stored under `public` directory and consequent runs won't incur additional processing time.
 
-Examine `src/pages/index.astro` and `astro.config.mts` sources for details.
+Examine `src/pages/index.astro` (markdown source transform), `src/pages/import.astro` (manual asset import) and `astro.config.mts` sources for details.

--- a/samples/astro/package.json
+++ b/samples/astro/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "astro": "^4.3.5",
-        "imgit": "^0.1.3"
+        "imgit": "^0.2.0"
     }
 }

--- a/samples/astro/package.json
+++ b/samples/astro/package.json
@@ -6,6 +6,6 @@
     },
     "dependencies": {
         "astro": "^4.3.5",
-        "imgit": "^0.2.0"
+        "imgit": "^0.2.1"
     }
 }

--- a/samples/astro/package.json
+++ b/samples/astro/package.json
@@ -5,7 +5,7 @@
         "preview": "astro preview"
     },
     "dependencies": {
-        "astro": "^4.1.1",
-        "imgit": "^0.1.2"
+        "astro": "^4.3.5",
+        "imgit": "^0.1.3"
     }
 }

--- a/samples/astro/src/env.d.ts
+++ b/samples/astro/src/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference types="imgit/client" />

--- a/samples/astro/src/pages/import.astro
+++ b/samples/astro/src/pages/import.astro
@@ -1,0 +1,31 @@
+---
+import psd from "imgit:https://github.com/elringus/imgit/raw/main/samples/assets/psd.psd";
+import mkv from "imgit:https://github.com/elringus/imgit/raw/main/samples/assets/mkv.mkv";
+---
+
+<html lang="en">
+
+<head>
+    <title>Astro Import Sample</title>
+    <meta charset="utf-8">
+    <link rel="icon" href="data:,">
+    <style is:global>
+        body { background: #222; }
+        img, video { max-width: 100%; height: auto; }
+    </style>
+</head>
+
+<body>
+
+<img src={psd.content.encoded}
+     height={psd.info.height}
+     loading="lazy"/>
+
+<video src={mkv.content.encoded}
+       poster={mkv.content.cover}
+       height={mkv.info.height}
+       autoplay loop/>
+
+</body>
+
+</html>

--- a/samples/astro/src/pages/index.astro
+++ b/samples/astro/src/pages/index.astro
@@ -12,6 +12,8 @@
 
 <body>
 
+<a href="/import">Import Sample</a>
+
 <!-- This file will be transformed by imgit when bundling with vite. Markdown image
      tags below will be replaced with <picture> and <video> HTML tags referencing
      generated content. Transformed files will be written under 'public' directory. -->

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,5 @@
 rm -rf dist
 tsc --build src
+cp src/client.d.ts dist
 cp src/client/styles.css dist/client
 cp src/plugin/youtube/styles.css dist/plugin/youtube

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,5 +1,5 @@
 ﻿/* v8 ignore start */
 declare module "imgit:*" {
-    const asset: import("server/import.js").AssetImport;
+    const asset: import("./server/import.js").AssetImport;
     export default asset;
 }

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,0 +1,5 @@
+﻿/* v8 ignore start */
+declare module "imgit:*" {
+    const asset: import("server/import.js").AssetImport;
+    export default asset;
+}

--- a/src/server/import.ts
+++ b/src/server/import.ts
@@ -1,0 +1,46 @@
+﻿import { stages } from "./transform/index.js";
+import { EncodedContent, ContentInfo, BuiltAsset } from "./asset.js";
+
+/** Result of importing asset via imgit. */
+export type AssetImport = {
+    /** Sources of the asset content. */
+    content: EncodedContent;
+    /** Content metadata. */
+    info: ContentInfo;
+}
+
+/** Whether specified import identifier is an imgit asset import. */
+export function isImgitAssetImport(importId: string): boolean {
+    return importId.startsWith("imgit:");
+}
+
+/** Resolves result (source code) of importing an imgit asset. */
+export async function importImgitAsset(importId: string): Promise<string> {
+    const url = importId.substring(6);
+    const asset = <BuiltAsset>{ syntax: { text: "", index: -1, url } };
+    stages.resolve.asset(asset);
+    await stages.fetch.asset(asset);
+    await stages.probe.asset(asset);
+    await stages.encode.asset(asset);
+    const size = stages.build.size(asset);
+    return `export default {
+                content: {
+                    encoded: ${buildSrc(asset.content.encoded)},
+                    dense: ${buildSrc(asset.content.dense)},
+                    cover: ${buildSrc(asset.content.cover)},
+                    safe: ${buildSrc(asset.content.safe)}
+                },
+                info: {
+                    type: "${asset.content.info.type}",
+                    height: ${size.height},
+                    width: ${size.width},
+                    alpha: ${asset.content.info.alpha}
+                }
+            }`;
+}
+
+function buildSrc(path?: string) {
+    if (path === undefined) return "undefined";
+    const src = stages.build.source(path);
+    return `"${src}"`;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ export { Plugin, PluginInjection } from "./config/plugin.js";
 export { ctx } from "./context.js";
 export { Cache, cache } from "./cache.js";
 export { stages, transform } from "./transform/index.js";
+export * as loader from "./import.js";
 export * from "./config/index.js";
 export * from "./asset.js";
 

--- a/src/server/transform/5-encode.ts
+++ b/src/server/transform/5-encode.ts
@@ -8,12 +8,12 @@ export async function encodeAll(assets: ProbedAsset[]): Promise<EncodedAsset[]> 
     await everythingIsFetched();
     for (const asset of assets)
         if (!(await encodeWithPlugins(<EncodedAsset>asset)))
-            await encodeAsset(<EncodedAsset>asset);
+            await encode(<EncodedAsset>asset);
     return <EncodedAsset[]>assets;
 }
 
 /** Encodes asset content with ffmpeg. */
-export async function encodeAsset(asset: EncodedAsset): Promise<void> {
+export async function encode(asset: EncodedAsset): Promise<void> {
     await encodeMain(asset.content, asset);
     await encodeSafe(asset.content, asset);
     await encodeDense(asset.content, asset);

--- a/src/server/transform/index.ts
+++ b/src/server/transform/index.ts
@@ -2,8 +2,8 @@ import { captureAll, capture } from "./1-capture.js";
 import { resolveAll, resolve, resolveSpec } from "./2-resolve.js";
 import { fetchAll, fetch } from "./3-fetch.js";
 import { probeAll, probe } from "./4-probe.js";
-import { encodeAll, encodeAsset } from "./5-encode.js";
-import { buildAll, build, buildContentSource, CONTAINER_ATTR } from "./6-build.js";
+import { encodeAll, encode } from "./5-encode.js";
+import { buildAll, build, resolveSource, CONTAINER_ATTR, resolveSize } from "./6-build.js";
 import { rewriteAll, rewrite } from "./7-rewrite.js";
 
 /** Individual document transformation stages. */
@@ -12,8 +12,8 @@ export const stages = {
     resolve: { asset: resolve, spec: resolveSpec },
     fetch: { asset: fetch },
     probe: { asset: probe },
-    encode: { asset: encodeAsset },
-    build: { asset: build, source: buildContentSource, CONTAINER_ATTR },
+    encode: { asset: encode },
+    build: { asset: build, source: resolveSource, size: resolveSize, CONTAINER_ATTR },
     rewrite: { content: rewrite }
 };
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,9 +4,7 @@
         "module": "NodeNext",
         "skipLibCheck": true,
         "strict": true,
-        "sourceMap": true,
         "declaration": true,
-        "declarationMap": true,
         "outDir": "../dist"
     }
 }

--- a/test/server/import.spec.ts
+++ b/test/server/import.spec.ts
@@ -1,0 +1,45 @@
+﻿import { it, expect, vi } from "vitest";
+import { boot } from "./common.js";
+import { isImgitAssetImport, importImgitAsset } from "../../src/server/import.js";
+import { ContentInfo, EncodedContent } from "../../src/server/index.js";
+
+it("assumes imgit import when starts with imgit:", async () => {
+    expect(isImgitAssetImport("foo")).toBeFalsy();
+    expect(isImgitAssetImport("imgit:foo")).toBeTruthy();
+});
+
+it("invokes build pipeline when importing imgit asset", async () => {
+    const info: ContentInfo = { alpha: true, width: 7, height: 6, type: "foo" };
+    const content: EncodedContent = { info, src: "", encoded: "bar", dense: "baz", local: "" };
+    const asset = { content };
+    vi.spyOn(await import("../../src/server/transform/index.js"), "stages", "get").mockReturnValue({
+        capture: { assets: vi.fn() },
+        resolve: { asset: vi.fn(), spec: vi.fn() },
+        fetch: { asset: vi.fn() },
+        probe: { asset: vi.fn() },
+        encode: { asset: vi.fn(async input => void Object.assign(input, asset)) },
+        build: {
+            asset: vi.fn(),
+            source: vi.fn(path => path),
+            size: vi.fn(() => ({ width: 1, height: 2 })),
+            CONTAINER_ATTR: ""
+        },
+        rewrite: { content: vi.fn() }
+    });
+    await boot();
+    const code = await importImgitAsset("imgit:foo");
+    expect(code).toStrictEqual(`export default {
+                content: {
+                    encoded: "bar",
+                    dense: "baz",
+                    cover: undefined,
+                    safe: undefined
+                },
+                info: {
+                    type: "foo",
+                    height: 2,
+                    width: 1,
+                    alpha: true
+                }
+            }`);
+});

--- a/test/server/vite.spec.ts
+++ b/test/server/vite.spec.ts
@@ -80,3 +80,29 @@ it("doesn't inject client module when disabled in plugin config", async () => {
         tags: []
     });
 });
+
+it("doesn't resolve non-imgit module imports", async () => {
+    vi.spyOn(await import("../../src/server/import.js"), "isImgitAssetImport").mockReturnValue(false);
+    expect(vite().resolveId("foo")).toBeNull();
+});
+
+it("resolves imgit module imports", async () => {
+    vi.spyOn(await import("../../src/server/import.js"), "isImgitAssetImport").mockReturnValue(true);
+    expect(vite().resolveId("foo")).toStrictEqual("foo");
+});
+
+it("doesn't load non-imgit import", async () => {
+    vi.spyOn(await import("../../src/server/import.js"), "isImgitAssetImport").mockReturnValue(false);
+    const load = vi.spyOn(await import("../../src/server/import.js"), "importImgitAsset");
+    load.mockImplementation(() => Promise.reject());
+    await vite().load("");
+    expect(load).not.toBeCalled();
+});
+
+it("loads imgit import", async () => {
+    vi.spyOn(await import("../../src/server/import.js"), "isImgitAssetImport").mockReturnValue(true);
+    const load = vi.spyOn(await import("../../src/server/import.js"), "importImgitAsset");
+    load.mockImplementation(() => Promise.resolve("foo"));
+    await vite().load("");
+    expect(load).toBeCalled();
+});


### PR DESCRIPTION
This adds an option to directly import media assets allowing to build HTML manually instead of transforming the sources.

Astro page example:

```astro
---
import psd from "imgit:https://example.com/photo.psd";
import mkv from "imgit:/assets/video.mkv";
---

<img src={psd.content.encoded}
     height={psd.info.height}
     loading="lazy"/>

<video src={mkv.content.encoded}
       poster={mkv.content.cover}
       height={mkv.info.height}
       autoplay loop/>
```

Documentation: https://imgit.dev/guide/asset-import